### PR TITLE
Not leaking file descriptors

### DIFF
--- a/src/jobTreeSlave.py
+++ b/src/jobTreeSlave.py
@@ -174,7 +174,8 @@ def main():
     
     #Log the number of open file descriptors so we can tell if we're leaking
     #them.
-    logger.debug("Next available descriptor: {}".format(nextOpenDescriptor()))
+    logger.debug("Next available file descriptor: {}".format(
+        nextOpenDescriptor()))
     
     ##########################################
     #Parse input files


### PR DESCRIPTION
jobTreeSlave.py's main method should no longer leak file descriptors. Additionally, the next available file descriptor number is now logged at debug level, so that a file descriptor leak (perhaps in the jobs being run) can be detected.
