### PR TITLE
Fixing crash when running with argparse

### DIFF
--- a/src/jobTreeRun.py
+++ b/src/jobTreeRun.py
@@ -146,7 +146,7 @@ def addOptions(parser):
         #parser.add_option_group(group)
     elif isinstance(parser, ArgumentParser):
         def addGroup(headingString, bodyString):
-            return parser.add_argument_group(parser, headingString, bodyString).add_argument
+            return parser.add_argument_group(headingString, bodyString).add_argument
         _addOptions(addGroup, "%(default)s")
     else:
         raise RuntimeError("Unanticipated class passed to addOptions(), %s. Expecting " 


### PR DESCRIPTION
Removing incorrect extra argument to argparse ArgumentParser.add_argument_group().
