### PR TITLE
Grid engine support for terabyte (T) MEMTOT output from qhost, and cpu specifications

### DIFF
--- a/batchSystems/gridengine.py
+++ b/batchSystems/gridengine.py
@@ -37,7 +37,7 @@ from jobTree.batchSystems.multijob import MultiTarget
 
 class MemoryString:
     def __init__(self, string):
-        if string[-1] == 'K' or string[-1] == 'M' or string[-1] == 'G':
+        if string[-1] == 'K' or string[-1] == 'M' or string[-1] == 'G' or string[-1] == 'T':
             self.unit = string[-1]
             self.val = float(string[:-1])
         else:
@@ -60,6 +60,8 @@ class MemoryString:
             return self.val * 1048576
         elif self.unit == 'G':
             return self.val * 1073741824
+        elif self.unit == 'T':
+            return self.val * 1099511627776
 
     def __cmp__(self, other):
         return cmp(self.bytes, other.bytes)

--- a/batchSystems/gridengine.py
+++ b/batchSystems/gridengine.py
@@ -71,7 +71,7 @@ def prepareQsub(cpu, mem):
                      "LD_LIBRARY_PATH=%s" % os.environ["LD_LIBRARY_PATH"]]
     reqline = list()
     if cpu is not None:
-        reqline.append("p="+str(cpu))
+        qsubline.extend(["-pe", "shm", str(int(cpu))])
     if mem is not None:
         reqline.append("vf="+str(mem/ 1024)+"K")
         reqline.append("h_vmem="+str(mem/ 1024)+"K")


### PR DESCRIPTION
The function obtainSystemConstants() in the GridEngineBatchSystem class in batchSystems/gridengine.py threw the error "ValueError: invalid literal for float(): 1.5T" when I tried to run it on a system that has 1.5T of available memory. I modified the MemoryString class to handle qhost output in the terabyte (T) range.

jobTree then worked fine, but the jobs it submitted to sge sat in queued "qw" state indefinitely. The reason was it was requesting a single processor per node via "qsub -l num_proc=1", but none of the nodes on my system have exactly one processor (they have more than that). I modified the prepareQsub(cpu, mem) function to use "qsub -pe shm 1". This now works on my system, but the function might have to be generalized to work on others (if something other than the shm parallel environment is being used).